### PR TITLE
Updates URL matches to include connection archives

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,9 +16,10 @@
     {
       "matches": [
         // Match the page for connections in the various ways it might be
-        // spelled with and without a trailing slash or query parameters. Note
-        // that the question marks are literal question marks, not wildcards as
-        // in `include_globs`. For completeness, I used a wildcard for the URL
+        // spelled with and without a trailing slash or query parameters and
+        // including subpaths such as the connections archive. Note that the
+        // question marks are literal question marks, not wildcards as in
+        // `include_globs`. For completeness, I used a wildcard for the URL
         // scheme and www even though these seem to always redirect to
         // https://www.nytimes.com
         "*://*.nytimes.com/games/connections",

--- a/manifest.json
+++ b/manifest.json
@@ -24,6 +24,7 @@
         "*://*.nytimes.com/games/connections",
         "*://*.nytimes.com/games/connections?*",
         "*://*.nytimes.com/games/connections/",
+        "*://*.nytimes.com/games/connections/*",
         "*://*.nytimes.com/games/connections/?*"
       ],
       "js": [

--- a/manifest.json
+++ b/manifest.json
@@ -23,9 +23,7 @@
         // https://www.nytimes.com
         "*://*.nytimes.com/games/connections",
         "*://*.nytimes.com/games/connections?*",
-        "*://*.nytimes.com/games/connections/",
-        "*://*.nytimes.com/games/connections/*",
-        "*://*.nytimes.com/games/connections/?*"
+        "*://*.nytimes.com/games/connections/*"
       ],
       "js": [
         "third_party/gsap.min.js",


### PR DESCRIPTION
Connection archive urls require matching after the slash: e.g. https://www.nytimes.com/games/connections/2023-07-18

This change updates `manifest.json` so the extension can work on games in the archive.